### PR TITLE
Fixed entrypoint.sh. Used to fail when serving (large) static files.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,27 @@
 #/bin/bash
 echo "Starting service..."
+
+# add specific files or their extensions to watch them 
+files_to_watch=("py" "*yaml" "Makefile" "")
+
+# create an associative map to check against
+declare -A map
+for ext in "${files_to_watch[@]}"; do
+  map["$ext"]=1
+done
+
+# main program loop
+# uses inotify to check whether files have been created, moved, edited etc.
 while true
 do
-        pkill -f python
-        make run &
-        inotifywait --exclude .swp -e create -e modify -e delete -e move -r /opt/service/
-        echo "Change detected. Reloading..."
+    inotifywait -m ./test -e create -e modify -e delete -e move -e moved_to |
+		while read path action file; do
+			file_extension=${file##*.}
+			
+			if [[ ${map["$file_extension"]} ]]; then 
+				pkill -f python
+				make run
+				echo "Change detected. Reloading..."
+			fi
+		done
 done

--- a/example/example/test.py
+++ b/example/example/test.py
@@ -1,0 +1,1 @@
+# changing this will trigger a refresh

--- a/example/example/test.txt
+++ b/example/example/test.txt
@@ -1,1 +1,2 @@
+# changing this file won't do anything
 working

--- a/example/main.py
+++ b/example/main.py
@@ -1,4 +1,2 @@
-import googlemaps
-from datetime import datetime
-
+# Python test file
 print("Hello world. 124")


### PR DESCRIPTION
Fixed entrypoint.sh. It used to watch all files which would fail when serving (large) static files. Made it watch only certain files to fix it.

Feel free to add any files (or extensions) your group needs to the array :)